### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ to `/tmp/docwatch.log`.
 Example config file
 ===================
 
-```conf
+```dosini
 [DEFAULT]
 
 # When using terminal editors such as vim, we start that in the terminal where


### PR DESCRIPTION
Fixed syntax highlighting for config section. According to [this languages YAML file](https://github.com/github/linguist/blob/b545f1c6befe87c2074e5e608f47ca0f6334d355/lib/linguist/languages.yml#L2195)
use `docini` as an alias to highlight config code snippets.